### PR TITLE
Add built-in MiniMax provider presets

### DIFF
--- a/src/components/ProviderPicker.tsx
+++ b/src/components/ProviderPicker.tsx
@@ -67,8 +67,8 @@ function getProviderDescription(provider: ResolvedProviderConfig): string {
       return 'Azure AI Foundry resource and credentials'
     case 'anthropic-compatible':
       return provider.baseURL
-        ? `Custom Anthropic-compatible provider · ${provider.baseURL}`
-        : 'Custom Anthropic-compatible provider'
+        ? `${provider.isCustom ? 'Custom ' : ''}Anthropic-compatible provider · ${provider.baseURL}`
+        : `${provider.isCustom ? 'Custom ' : ''}Anthropic-compatible provider`
     case 'openai-compatible':
       return provider.baseURL
         ? `Custom OpenAI-compatible provider · ${provider.baseURL}`

--- a/src/utils/model/providerConfig.test.ts
+++ b/src/utils/model/providerConfig.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+const configDir = mkdtempSync(join(tmpdir(), 'provider-config-'))
+process.env.CLAUDE_CONFIG_DIR = configDir
+
+const {
+  getAllProviderConfigs,
+  getProviderConfigById,
+  getSuggestedModelForProvider,
+} = await import('./providerConfig.js')
+
+afterAll(() => {
+  if (previousConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+  }
+  rmSync(configDir, { recursive: true, force: true })
+})
+
+describe('MiniMax provider presets', () => {
+  test.each([
+    ['minimax', 'MiniMax', 'https://api.minimax.io/anthropic'],
+    ['minimax-cn', 'MiniMax (China)', 'https://api.minimaxi.com/anthropic'],
+  ])('resolves %s', (id, name, baseURL) => {
+    expect(getProviderConfigById(id)).toMatchObject({
+      id,
+      type: 'anthropic-compatible',
+      name,
+      baseURL,
+      authTokenEnv: 'MINIMAX_API_KEY',
+      defaultModel: 'MiniMax-M3',
+      models: ['MiniMax-M3', 'MiniMax-M2.7'],
+      isCustom: false,
+    })
+  })
+
+  test('lists both regional presets and selects the default model', () => {
+    const providerIds = getAllProviderConfigs().map(provider => provider.id)
+
+    expect(providerIds).toContain('minimax')
+    expect(providerIds).toContain('minimax-cn')
+    expect(getSuggestedModelForProvider('minimax', null)).toBe('MiniMax-M3')
+  })
+})

--- a/src/utils/model/providerConfig.ts
+++ b/src/utils/model/providerConfig.ts
@@ -48,6 +48,8 @@ export type ResolvedProviderConfig = ActiveProviderConfig
 
 type BuiltinProviderId =
   | 'firstParty'
+  | 'minimax'
+  | 'minimax-cn'
   | 'bedrock'
   | 'vertex'
   | 'foundry'
@@ -56,6 +58,8 @@ type BuiltinProviderId =
 
 const BUILTIN_PROVIDER_NAMES: Record<BuiltinProviderId, string> = {
   firstParty: 'Anthropic',
+  minimax: 'MiniMax',
+  'minimax-cn': 'MiniMax (China)',
   bedrock: 'Amazon Bedrock',
   vertex: 'Google Vertex AI',
   foundry: 'Azure AI Foundry',
@@ -65,6 +69,8 @@ const BUILTIN_PROVIDER_NAMES: Record<BuiltinProviderId, string> = {
 
 const BUILTIN_PROVIDER_IDS = new Set<BuiltinProviderId>([
   'firstParty',
+  'minimax',
+  'minimax-cn',
   'bedrock',
   'vertex',
   'foundry',
@@ -74,6 +80,8 @@ const BUILTIN_PROVIDER_IDS = new Set<BuiltinProviderId>([
 
 const BUILTIN_PROVIDER_ORDER: BuiltinProviderId[] = [
   'firstParty',
+  'minimax',
+  'minimax-cn',
   'github-copilot',
   'github-models',
   'bedrock',
@@ -82,12 +90,26 @@ const BUILTIN_PROVIDER_ORDER: BuiltinProviderId[] = [
 ]
 
 const BUILTIN_PROVIDER_CONFIGS: Record<
-  'github-models' | 'github-copilot',
+  'minimax' | 'minimax-cn' | 'github-models' | 'github-copilot',
   Pick<
     ActiveProviderConfig,
     'type' | 'baseURL' | 'authTokenEnv' | 'defaultModel' | 'models' | 'smallFastModel'
   >
 > = {
+  minimax: {
+    type: 'anthropic-compatible',
+    baseURL: 'https://api.minimax.io/anthropic',
+    authTokenEnv: 'MINIMAX_API_KEY',
+    defaultModel: 'MiniMax-M3',
+    models: ['MiniMax-M3', 'MiniMax-M2.7'],
+  },
+  'minimax-cn': {
+    type: 'anthropic-compatible',
+    baseURL: 'https://api.minimaxi.com/anthropic',
+    authTokenEnv: 'MINIMAX_API_KEY',
+    defaultModel: 'MiniMax-M3',
+    models: ['MiniMax-M3', 'MiniMax-M2.7'],
+  },
   'github-models': {
     type: 'github-models',
     baseURL: 'https://models.github.ai/inference',
@@ -195,7 +217,12 @@ function getBuiltinProviderConfig(id: BuiltinProviderId): ActiveProviderConfig {
     }
   }
 
-  if (id === 'github-models' || id === 'github-copilot') {
+  if (
+    id === 'minimax' ||
+    id === 'minimax-cn' ||
+    id === 'github-models' ||
+    id === 'github-copilot'
+  ) {
     const config = BUILTIN_PROVIDER_CONFIGS[id]
     return {
       id,


### PR DESCRIPTION
Reason: Add built-in MiniMax presets so users can select current models and the appropriate regional endpoint without custom configuration.

## Changes

- Add global and China MiniMax provider presets.
- Configure the current MiniMax models and bearer-token environment variable.
- Add focused coverage for preset resolution and default model selection.

## Checks

- `bun test src/utils/model/providerConfig.test.ts`
- `bun run version`
- `git diff --check`
